### PR TITLE
setup: add repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fast and simple alignments in Python:
 
-![Example inside Jupyter](https://github.com/poke1024/pyalign/blob/main/docs/jupyter_example.png)
+![Example inside Jupyter](https://github.com/poke1024/pyalign/raw/main/docs/jupyter_example.png)
 
 <hr>
 
@@ -167,9 +167,9 @@ The following benchmarks were done on an Apple M1 Max. SIMD-128 refers to the M1
 
 The benchmark code can be found under [benchmark.py](demo/py/benchmark.py).
 
-![traceback and path](docs/benchmark_10_100.svg)
+![traceback and path](https://raw.githubusercontent.com/poke1024/pyalign/main/docs/benchmark_10_100.svg)
 
-![traceback and path](docs/benchmark_5000_10000.svg)
+![traceback and path](https://raw.githubusercontent.com/poke1024/pyalign/main/docs/benchmark_5000_10000.svg)
 
 # Other Alignment Libraries
 

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
 	license='MIT',
 	author='Bernhard Liebl',
 	author_email='liebl@informatik.uni-leipzig.de',
+	url='https://github.com/poke1024/pyalign',
 	ext_modules=ext_modules,
 	cmdclass={"build_ext": build_ext},
 	install_requires=required,


### PR DESCRIPTION
The [project page on PyPI](https://pypi.org/project/pyalign/) lacks a backref to Github due to this.

(Most images in the README do not render there, too.)